### PR TITLE
feat: use dpr srcset for images with mark param

### DIFF
--- a/tools/pipelines/pipeline.nunjucks.js
+++ b/tools/pipelines/pipeline.nunjucks.js
@@ -65,8 +65,19 @@ module.exports = function setupNunjucksPipeline(gulp) {
                 path = attributes['ix-path'],
                 params = attributes['ix-params'] ? JSON.parse(attributes['ix-params']) : {},
                 imgURL,
-                maxWidth
+                maxWidth,
+                minWidth;
 
+            /**
+             * If the img tag has an `ix-path` attribute
+             * - the tag will have either an `ix-host` or will default to 'ix-www.imgix.net'
+             * - the tag won't have an `ix-src` attribute, the params will be in the URL or `ix-params` attribute
+             * - imageURL.searchParams will not get merged with `ix-params` for `ix-path` tags
+             * 
+             * If the img tag doesn't have an `ix-path` attribute
+             * - the tag will have either an `ix-src` attribute or a `src` attribute
+             * - the params will be in the URL or `ix-params` attribute. If they exist in both, they will be merged.
+             */
             if (path) {
               client.settings.domain = attributes['ix-host'] ?? 'ix-www.imgix.net';
             } else {
@@ -76,24 +87,35 @@ module.exports = function setupNunjucksPipeline(gulp) {
               params = Object.assign(Object.fromEntries(imgURL.searchParams), params);
             }
 
+            // Add `compress` and `format` to the auto param if they aren't already there
             params.auto = params.auto ? Array.from(new Set(params.auto.split(',')).add('compress').add('format')).join(',') : 'compress,format';
 
             if (imgTag.name === 'img') attributes['src'] = client.buildURL(path, params, { disablePathEncoding: true });
 
-            if (params.w && params.h && params.fit !== 'facearea') {
+            maxWidth = Math.max(Number(params.w ?? 1800), 1800);
+            minWidth = 100;
+
+            // Ensure that the `mark` param widths are never smaller than the `w` param width.
+            if (params.mark && params.w) {
+              minWidth = params.w
+            }
+
+            // Params that require DPR srcsets
+            const useDprSrcset = params.fit === 'facearea' || !!params.mark;
+            /**
+             * Passing `w` and `h` params to `buildSrcSet` will
+             * create a DPR srcset. We remove the width and height attributes in
+             * order to use width srcsets. 
+             */
+            if (params.w && params.h && !useDprSrcset) {
               params.ar = params.w + ':' + params.h;
               params.fit = params.fit ?? 'crop';
 
               delete params.h;
-            }
-
-            maxWidth = Math.max(Number(params.w ?? 1800), 1800);
-
-            if (params.fit !== 'facearea') {
               delete params.w;
             }
 
-            attributes['srcset'] = client.buildSrcSet(path, params, { minWidth: 100, maxWidth: maxWidth, disablePathEncoding: true });
+            attributes['srcset'] = client.buildSrcSet(path, params, { minWidth, maxWidth: maxWidth, disablePathEncoding: true });
             attributes['sizes'] = (attributes['sizes'] ?? attributes['ix-sizes']) ?? '100vw';
           })
 

--- a/tools/pipelines/pipeline.nunjucks.js
+++ b/tools/pipelines/pipeline.nunjucks.js
@@ -90,7 +90,24 @@ module.exports = function setupNunjucksPipeline(gulp) {
             // Add `compress` and `format` to the auto param if they aren't already there
             params.auto = params.auto ? Array.from(new Set(params.auto.split(',')).add('compress').add('format')).join(',') : 'compress,format';
 
-            if (imgTag.name === 'img') attributes['src'] = client.buildURL(path, params, { disablePathEncoding: true });
+            /**
+             * Disable encoding for base64 params to avoid double encoding
+             * @param {String} value
+             * @param {String} key
+             * @returns {Sting}
+             */
+            const encoder =(value, key) => {
+              return typeof key == 'string' && key?.substring(key.length-2, key.length) === '64' ? value : encodeURIComponent(value)
+            }
+
+            if (imgTag.name === 'img') attributes['src'] = client.buildURL(
+              path,
+              params,
+              {
+                disablePathEncoding: true,
+                encoder,
+              }
+            );
 
             maxWidth = Math.max(Number(params.w ?? 1800), 1800);
             minWidth = 100;
@@ -115,7 +132,16 @@ module.exports = function setupNunjucksPipeline(gulp) {
               delete params.w;
             }
 
-            attributes['srcset'] = client.buildSrcSet(path, params, { minWidth, maxWidth: maxWidth, disablePathEncoding: true });
+            attributes['srcset'] = client.buildSrcSet(
+              path,
+              params,
+              {
+                minWidth,
+                maxWidth: maxWidth,
+                disablePathEncoding: true,
+                encoder,
+              }
+            );
             attributes['sizes'] = (attributes['sizes'] ?? attributes['ix-sizes']) ?? '100vw';
           })
 


### PR DESCRIPTION
# Description

This PR refactors some of the `<img>` tag parsing logic to allow for using DPR srcset on images that use the `mark=` param. Before this commit, there was an issue where the mark images had a different minimum width than the `src` image. This could lead to issues when using the mark as a layer to, for example, change a product's color.

## Screenshots 🖼️ 
![use-dpr-srcset-for-images-with-mark-param](https://github.com/imgix/web-tools-nunjucks/assets/16711614/9c713720-0a3b-42e3-a3d0-87c1d5839a8e)
