### PR TITLE
fix: remove dpr srcset for mark param images

### DIFF
--- a/tools/pipelines/pipeline.nunjucks.js
+++ b/tools/pipelines/pipeline.nunjucks.js
@@ -118,7 +118,7 @@ module.exports = function setupNunjucksPipeline(gulp) {
             }
 
             // Params that require DPR srcsets
-            const useDprSrcset = params.fit === 'facearea' || !!params.mark;
+            const useDprSrcset = params.fit === 'facearea';
             /**
              * Passing `w` and `h` params to `buildSrcSet` will
              * create a DPR srcset. We remove the width and height attributes in
@@ -132,16 +132,26 @@ module.exports = function setupNunjucksPipeline(gulp) {
               delete params.w;
             }
 
-            attributes['srcset'] = client.buildSrcSet(
-              path,
-              params,
-              {
-                minWidth,
-                maxWidth: maxWidth,
-                disablePathEncoding: true,
-                encoder,
-              }
-            );
+            /**
+             * If the `mark` param is present, we need to disable adding the
+             * `srcset` attribute to the img tag. This is because the `mark`
+             * param image will receive a `w` param that is different from the
+             * `w` param of the main image. This will cause the `srcset` to
+             * contain the wrong widths.
+             */
+            if(!params.mark){
+              attributes['srcset'] = client.buildSrcSet(
+                path,
+                params,
+                {
+                  minWidth,
+                  maxWidth: maxWidth,
+                  disablePathEncoding: true,
+                  encoder,
+                }
+              );
+            }
+
             attributes['sizes'] = (attributes['sizes'] ?? attributes['ix-sizes']) ?? '100vw';
           })
 


### PR DESCRIPTION
# Description
Turn of `srcset` generation for images with `mark=` param.

## How to test
1. Pull down
2. Run `yarn link web-tools-nunjucks` in `/blog`
3. Run `yarn dev`
4. Go to [blog](http://localhost:9080/2020/05/19/cartrawler-dynamic-coloring-imgix) post
5. See images render correctly

## Links
- Related PRs: #3 

## Screenshots 🖼️ 
<img width="1128" alt="remove-dpr-srcset" src="https://github.com/imgix/web-tools-nunjucks/assets/16711614/65272e4f-8bb4-4dc6-873b-50431580940e">


## What I Learned 📚 
`dpr=` where DPR > 1 breaks the image because the dpr= param only gets applied to the `mark=` image (making it larger than the base layer). This didn't get caught because the browser where testing was done had a DPR of 1, where base and layer matched DPR resolutions. 

It's not intuitive, but adding `dpr=` to the params has the same side-effect as adding `w=` if the last param is `mark=`, where the mark image gets resized but the base image does not.